### PR TITLE
Fix results length to match `max_papers`

### DIFF
--- a/sciencer/providers/semantic_scholar_provider.py
+++ b/sciencer/providers/semantic_scholar_provider.py
@@ -210,7 +210,7 @@ class SemanticScholarProvider(Provider):
             resulting_papers.update([create_paper_from_json(
                 paper_json) for paper_json in response_json["data"]])
 
-            remaining_papers -= len(response_json["data"])
+            remaining_papers = max_papers - len(resulting_papers)
 
             if "next" not in response_json:
                 break


### PR DESCRIPTION
We were assuming the results from the `collect_by_terms` were unique, which is not true if the collector finds repeated papers.

Instead of considering the length of the response data, we are now using the length of unique papers actually added to the resulting papers. This guarantees the number of results will always match the `max_papers` parameter.