### PR TITLE
Clean LogCallbacks

### DIFF
--- a/examples/example_2_research_group_report.py
+++ b/examples/example_2_research_group_report.py
@@ -5,8 +5,10 @@ from sciencer import Sciencer
 from sciencer.providers import SemanticScholarProvider
 from sciencer.collectors import CollectByAuthorID
 from sciencer.filters import FilterByYear
+from sciencer.utils import HistoryCallbacks
 
-researchers = ["145136631", "3233831", "1816411", "145813496", "145955156", "145125979", "2151066261", "144518313", "2158393415", "143825592"]
+researchers = ["145136631", "3233831", "1816411", "145813496", "145955156",
+               "145125979", "2151066261", "144518313", "2158393415", "143825592"]
 
 if __name__ == "__main__":
 
@@ -15,8 +17,12 @@ if __name__ == "__main__":
 
     for researcher in researchers:
         s.add_collector(CollectByAuthorID(author_id=researcher))
-    
+
     s.add_filter(FilterByYear(min_year=2022, max_year=2022))
-    
-    for paper in s.iterate( remove_source_from_results=False):
+
+    history_cb = HistoryCallbacks()
+
+    for paper in s.iterate(remove_source_from_results=False, callbacks=[history_cb]):
         print(f"{paper.year}@{paper.paper_id} - {paper.title} => {paper.authors}")
+
+    history_cb.dump()

--- a/examples/example_2_research_group_report.py
+++ b/examples/example_2_research_group_report.py
@@ -22,7 +22,6 @@ if __name__ == "__main__":
 
     history_cb = HistoryCallbacks()
 
-    for paper in s.iterate(remove_source_from_results=False, callbacks=[history_cb]):
-        print(f"{paper.year}@{paper.paper_id} - {paper.title} => {paper.authors}")
+    s.iterate(remove_source_from_results=False, callbacks=[history_cb])
 
     history_cb.dump()

--- a/sciencer/core.py
+++ b/sciencer/core.py
@@ -1,6 +1,6 @@
 """ Sciencer Core
 """
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set
 from sciencer.collectors.collector import Collector
 from sciencer.expanders.expander import Expander
 from sciencer.filters.filter import Filter
@@ -61,67 +61,6 @@ class Callbacks:
         Args:
             paper (Paper): rejected paper.
         """
-
-
-class PaperLog:
-    """Log of the paper's lifecycle during a iteration
-    """
-
-    def __init__(self, paper: Paper) -> None:
-        self.paper: Paper = paper
-        self.__collected_from: List[Collector] = []
-        self.__expanded_from: List[Tuple[Paper, Expander]] = []
-        self.__filtered_by: List[Tuple[Filter, bool]] = []
-
-    def add_collector_source(self, collector: Collector) -> None:
-        """Adds a new collector to the log
-
-        Args:
-            collector (Collector): collector used to fetch the paper
-        """
-        self.__collected_from.append(collector)
-
-    def add_expander_source(self, expander: Expander, source_paper: Paper) -> None:
-        """Adds a new expander to the log
-
-        Args:
-            expander (Expander): expander that fetched this paper
-            source_paper (Paper): paper used during the expansion
-        """
-        self.__expanded_from.append((source_paper, expander))
-
-    def add_filter_tested(self, filter_tested: Filter, result: bool) -> None:
-        """Add a new filter to the log
-
-        Args:
-            filter_tested (Filter): filter that tested this paper
-            result (bool): if the filter was satisfied, it is True. Otherwise, it is False
-        """
-        self.__filtered_by.append((filter_tested, result))
-
-
-class LogCallbacks(Callbacks):
-    """Logs the history of all the papers
-    """
-
-    def __init__(self) -> None:
-        self.__paper_logs: Dict[Paper, PaperLog] = {}
-
-    def on_paper_collected(self, paper: Paper, collector: Collector) -> None:
-        if paper not in self.__paper_logs:
-            self.__paper_logs[paper] = PaperLog(paper)
-        self.__paper_logs[paper].add_collector_source(collector)
-
-    def on_paper_expanded(self, new_paper: Paper, expander: Expander, source_paper: Paper) -> None:
-        if new_paper not in self.__paper_logs:
-            self.__paper_logs[new_paper] = PaperLog(new_paper)
-        self.__paper_logs[new_paper].add_expander_source(
-            expander, source_paper)
-
-    def on_paper_filtered(self, paper: Paper, filter_executed: Filter, result: bool) -> None:
-        if paper not in self.__paper_logs:
-            self.__paper_logs[paper] = PaperLog(paper)
-        self.__paper_logs[paper].add_filter_tested(filter_executed, result)
 
 
 class Sciencer:
@@ -226,7 +165,6 @@ class Sciencer:
             List[Paper]: the resulting collection of papers
         """
         callbacks = [] if callbacks is None else callbacks
-        callbacks.append(LogCallbacks())
 
         if source_papers is None:
             source_papers = set()

--- a/sciencer/utils/__init__.py
+++ b/sciencer/utils/__init__.py
@@ -1,4 +1,4 @@
 """Utilities for Sciencer toolkit
 """
 from .csv_callback import WriteToCSVCallbacks
-from .history_callback import HistoryCallbacks
+from .history_callback import HistoryCallbacks, HistoryLog

--- a/sciencer/utils/__init__.py
+++ b/sciencer/utils/__init__.py
@@ -1,3 +1,4 @@
 """Utilities for Sciencer toolkit
 """
 from .csv_callback import WriteToCSVCallbacks
+from .history_callback import HistoryCallbacks

--- a/sciencer/utils/history_callback.py
+++ b/sciencer/utils/history_callback.py
@@ -91,16 +91,17 @@ class HistoryCallbacks(Callbacks):
         """Dumps the history of all the papers registered in the callback
         """
         for paper, log in self.__paper_logs.items():
-            print(f"{paper.title}")
+            print(f"# {paper.title}")
             if len(log.collectors) > 0:
-                print("Collectors:")
+                print("## Collectors:")
                 for collector in log.collectors:
                     print(f" > {str(collector)}")
             if len(log.expanders) > 0:
-                print("Expanders:")
+                print("## Expanders:")
                 for expander in log.expanders:
                     print(f" > {str(expander[1])} + {str(expander[0])}")
             if len(log.filters) > 0:
-                print("Filters:")
+                print("## Filters:")
                 for m_filter in log.filters:
                     print(f" > {str(m_filter[0])} => {m_filter[1]}")
+            print()

--- a/sciencer/utils/history_callback.py
+++ b/sciencer/utils/history_callback.py
@@ -9,7 +9,7 @@ from sciencer.expanders import Expander
 from sciencer.filters import Filter
 
 
-class PaperLog:
+class HistoryLog:
     """Log of the paper's lifecycle during a iteration
     """
 
@@ -69,23 +69,31 @@ class HistoryCallbacks(Callbacks):
     """
 
     def __init__(self) -> None:
-        self.__paper_logs: Dict[Paper, PaperLog] = {}
+        self.__paper_logs: Dict[Paper, HistoryLog] = {}
 
     def on_paper_collected(self, paper: Paper, collector: Collector) -> None:
         if paper not in self.__paper_logs:
-            self.__paper_logs[paper] = PaperLog(paper)
+            self.__paper_logs[paper] = HistoryLog(paper)
         self.__paper_logs[paper].add_collector_source(collector)
 
     def on_paper_expanded(self, new_paper: Paper, expander: Expander, source_paper: Paper) -> None:
         if new_paper not in self.__paper_logs:
-            self.__paper_logs[new_paper] = PaperLog(new_paper)
+            self.__paper_logs[new_paper] = HistoryLog(new_paper)
         self.__paper_logs[new_paper].add_expander_source(
             expander, source_paper)
 
     def on_paper_filtered(self, paper: Paper, filter_executed: Filter, result: bool) -> None:
         if paper not in self.__paper_logs:
-            self.__paper_logs[paper] = PaperLog(paper)
+            self.__paper_logs[paper] = HistoryLog(paper)
         self.__paper_logs[paper].add_filter_tested(filter_executed, result)
+
+    @property
+    def papers_history(self) -> Dict[Paper, HistoryLog]:
+        """The history of all papers mentioned during the expansion
+        Returns:
+            Dict[Paper, HistoryLog]: A dictionary mapping each paper and respective log
+        """        """"""
+        return self.__paper_logs
 
     def dump(self) -> None:
         """Dumps the history of all the papers registered in the callback

--- a/sciencer/utils/history_callback.py
+++ b/sciencer/utils/history_callback.py
@@ -1,0 +1,106 @@
+"""Callbacks to report the history of a paper during one iteration
+"""
+
+from typing import List, Dict, Tuple
+from sciencer.core import Callbacks
+from sciencer.models import Paper
+from sciencer.collectors import Collector
+from sciencer.expanders import Expander
+from sciencer.filters import Filter
+
+
+class PaperLog:
+    """Log of the paper's lifecycle during a iteration
+    """
+
+    def __init__(self, paper: Paper) -> None:
+        self.paper: Paper = paper
+        self.__collected_from: List[Collector] = []
+        self.__expanded_from: List[Tuple[Paper, Expander]] = []
+        self.__filtered_by: List[Tuple[Filter, bool]] = []
+
+    def add_collector_source(self, collector: Collector) -> None:
+        """Adds a new collector to the log
+
+        Args:
+            collector (Collector): collector used to fetch the paper
+        """
+        self.__collected_from.append(collector)
+
+    def add_expander_source(self, expander: Expander, source_paper: Paper) -> None:
+        """Adds a new expander to the log
+
+        Args:
+            expander (Expander): expander that fetched this paper
+            source_paper (Paper): paper used during the expansion
+        """
+        self.__expanded_from.append((source_paper, expander))
+
+    def add_filter_tested(self, filter_tested: Filter, result: bool) -> None:
+        """Add a new filter to the log
+
+        Args:
+            filter_tested (Filter): filter that tested this paper
+            result (bool): if the filter was satisfied, it is True. Otherwise, it is False
+        """
+        self.__filtered_by.append((filter_tested, result))
+
+    @property
+    def collectors(self) -> List[Collector]:
+        """The collectors used to retrieve this paper
+        """
+        return self.__collected_from
+
+    @property
+    def expanders(self) -> List[Tuple[Paper, Expander]]:
+        """The expanders that gathered this papers
+        """
+        return self.__expanded_from
+
+    @property
+    def filters(self) -> List[Tuple[Filter, bool]]:
+        """The filters applied to this paper
+        """
+        return self.__filtered_by
+
+
+class HistoryCallbacks(Callbacks):
+    """Logs the history of all the papers
+    """
+
+    def __init__(self) -> None:
+        self.__paper_logs: Dict[Paper, PaperLog] = {}
+
+    def on_paper_collected(self, paper: Paper, collector: Collector) -> None:
+        if paper not in self.__paper_logs:
+            self.__paper_logs[paper] = PaperLog(paper)
+        self.__paper_logs[paper].add_collector_source(collector)
+
+    def on_paper_expanded(self, new_paper: Paper, expander: Expander, source_paper: Paper) -> None:
+        if new_paper not in self.__paper_logs:
+            self.__paper_logs[new_paper] = PaperLog(new_paper)
+        self.__paper_logs[new_paper].add_expander_source(
+            expander, source_paper)
+
+    def on_paper_filtered(self, paper: Paper, filter_executed: Filter, result: bool) -> None:
+        if paper not in self.__paper_logs:
+            self.__paper_logs[paper] = PaperLog(paper)
+        self.__paper_logs[paper].add_filter_tested(filter_executed, result)
+
+    def dump(self) -> None:
+        """Dumps the history of all the papers registered in the callback
+        """
+        for paper, log in self.__paper_logs.items():
+            print(f"{paper.title}")
+            if len(log.collectors) > 0:
+                print("Collectors:")
+                for collector in log.collectors:
+                    print(f" > {str(collector)}")
+            if len(log.expanders) > 0:
+                print("Expanders:")
+                for expander in log.expanders:
+                    print(f" > {str(expander[1])} + {str(expander[0])}")
+            if len(log.filters) > 0:
+                print("Filters:")
+                for m_filter in log.filters:
+                    print(f" > {str(m_filter[0])} => {m_filter[1]}")


### PR DESCRIPTION
Solves #11.

Renamed from LogCallbacks to HistoryCallbacks.

Added methods to:
- retrieve each history (dict between papers and log)
- dump all papers in the history
